### PR TITLE
Fix config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://mattmazur.com/2021/11/18/using-a-phantom-wallet-address-with-the-solana-
 
 Ensure a SOL funded private keypair is in this file location: 
 ```
-~/.solana/config/entropy-mainnet-authority.json
+~/.config/solana/entropy-mainnet-authority.json
 ```
 
 Run the keeper


### PR DESCRIPTION
The README points to `~/.solana/config` instead of `~/.config/solana`